### PR TITLE
dropdown-menu placement correction

### DIFF
--- a/WEEK_4/src/FlaskBlogApp/templates/navbar.html
+++ b/WEEK_4/src/FlaskBlogApp/templates/navbar.html
@@ -23,7 +23,7 @@
               <img class="rounded-circle navbar-profile-image" src="{{ url_for('static', filename='images/profiles_images/'+current_user.profile_image) }}" alt="{{ current_user.username }}" data-holder-rendered="true" data-bs-toggle="tooltip" data-bs-placement="top", title="{{ current_user.username }}" >
             </a>
             
-            <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
             
               <li>
                 <a class="dropdown-item" href="/account/">{{ current_user.username }}</a>


### PR DESCRIPTION
V4.5.1 20:25
Το πλαίσιο από το dropdown menu του προφίλ χρήστη, μου εμφανιζόταν τέρμα αριστερά στην οθόνη (Firefox 91.5.0esr, Debian testing)
Τώρα εμφανίζεται ολόκληρο στην δεξιά πλευρά χωρίς να προεξέχει.